### PR TITLE
Fix Issue #8 - added parameters to fetch.py

### DIFF
--- a/fetch_jira_bugs/fetch.py
+++ b/fetch_jira_bugs/fetch.py
@@ -10,11 +10,12 @@ import json
 import os
 import argparse
 import io
+import sys
 
-def fetch():
+def fetch(project_issue_code, jira_project_name):
     """ Fetch issues that match given jql query """
     # Jira Query Language string which filters for resolved issues of type bug
-    jql = 'project = JENKINS '\
+    jql = 'project = ' + project_issue_code + ' ' \
         + 'AND issuetype = Bug '\
         + 'AND status in (Resolved, Closed) '\
         + 'AND resolution = Fixed '\
@@ -30,7 +31,7 @@ def fetch():
     max_results = 1000
 
     os.makedirs('issues/', exist_ok=True)
-    request = 'https://issues.jenkins-ci.org/rest/api/2/search?'\
+    request = 'https://' + jira_project_name + '/rest/api/2/search?'\
         + 'jql={}&start_at={}&max_results={}'
 
     # Do small request to establish value of 'total'
@@ -51,4 +52,15 @@ def fetch():
     print('\nDone!')
 
 if __name__ == '__main__':
-    fetch()
+
+	parser = argparse.ArgumentParser(description="""Convert a git log output to json.
+                                                 """)
+	parser.add_argument('--issue-code', type=str,
+        	help="The code used for the project issues on JIRA: e.g., JENKINS-1123. Only JENKINS needs to be passed as parameter.")
+	parser.add_argument('--jira-project', type=str,
+            help="The name of the Jira repository of the project.")
+
+	args = parser.parse_args()
+	project_issue_code = args.issue_code
+	jira_project_name = args.jira_project
+	fetch(project_issue_code, jira_project_name)

--- a/fetch_jira_bugs/git_log_to_array.py
+++ b/fetch_jira_bugs/git_log_to_array.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description="""Convert a git log output to json.
                                                  """)
-    parser.add_argument('--from-commit', type=str, default="02d6908ada70fcf8012833ddef628bc09c6f8389",
+    parser.add_argument('--from-commit', type=str,
             help="A SHA-1 representing a commit. Runs git rev-list from this commit.")
     parser.add_argument('--repo-path', type=str,
             help="The absolute path to a local copy of the git repository from where the git log is taken.")


### PR DESCRIPTION
- _Fetch.py_ now requires two parameters for the Jira issue code and project repository name (as discussed in issue #8 ) 
- git_to_log_array has been consequently modified to remove the standard value (_02d6908ada70fcf8012833ddef628bc09c6f8389_) of the parameter _--from-commit_  since it refers to a commit in the Jenkins project.