### PR TITLE
Update GitParser.java, Fix Fatal Bug

### DIFF
--- a/szz/src/main/java/parser/GitParser.java
+++ b/szz/src/main/java/parser/GitParser.java
@@ -209,7 +209,7 @@ public class GitParser {
       index = delIndexes.get(i);
       if (index == -1) continue;
       try {
-        RevCommit foundRev = found.getSourceCommit(i);
+        RevCommit foundRev = found.getSourceCommit(index);
 
         if (!foundRevisions.containsKey(foundRev)) {
           Map<Integer, Integer> blamedLines = new LinkedHashMap<>();


### PR DESCRIPTION
fix: fix git blame get the wrong line source commit, use index instead