### PR TITLE
fix(docker): Update deprecated base image to eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 RUN apk add --no-cache --update python3 git
 


### PR DESCRIPTION
The original java:8-jdk-alpine base image is deprecated and no longer available on Docker Hub, causing the build to fail.

This commit updates the Dockerfile to use eclipse-temurin:8-jdk-alpine, which is the current, maintained equivalent for Java 8 on Alpine. This resolves the build error.